### PR TITLE
force the first column of the outcomes file to be PatientID

### DIFF
--- a/src/utils/feature-utils.js
+++ b/src/utils/feature-utils.js
@@ -301,6 +301,11 @@ export async function validateLabelFile(file, dataPoints, headerFieldNames) {
 
     let headerFields = firstLine.split(separator);
 
+    if (headerFields[0] != "PatientID"){
+      error = `Expected the first column to be PatientID - got ${headerFields[0]}`
+      return [false, error]
+    }
+
     let hasHeader =
       headerFields.length === fullHeaderFieldNames.length &&
       fullHeaderFieldNames.every((fieldName) =>


### PR DESCRIPTION
- before the outcome file loading would accept the first column to be named with any name - now we force the title of the first column to be PatientID