### PR TITLE
adding error message if list cannot be used as input

### DIFF
--- a/src/components/ModelsTable.js
+++ b/src/components/ModelsTable.js
@@ -1,6 +1,6 @@
 import { useSortBy, useTable } from 'react-table';
 import React, { useEffect, useState } from 'react';
-import { Button, Collapse, Table, UncontrolledTooltip } from 'reactstrap';
+import { Alert, Button, Collapse, Table, UncontrolledTooltip } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { DATA_SPLITTING_TYPES } from '../config/constants';
 import MyModal from './MyModal';
@@ -24,6 +24,8 @@ export default function ModelsTable({
 
   let [patientIDs, setPatientIDs] = useState(null);
   let [patientIDsOpen, setPatientIDsOpen] = useState(false);
+  let [isCompareModelCorrect, setIsCompareModelCorrect] = useState(true);
+  let [isCompareModelCorrectMessage, setIsCompareModelCorrectMessage] = useState("");
 
   const { keycloak } = useKeycloak();
 
@@ -234,16 +236,20 @@ export default function ModelsTable({
   };
 
   const handleCompareModels = async () => {
-    console.log("doing notttthhiiiiiiiinnnnnggggg");
-    console.log(compareModelsValue);
     if (compareModelsValue != null) {
-      let compareModelsArray = compareModelsValue.split(",").map(Number);
-      let { filename, content } = await Backend.compareModels(
-        keycloak.token,
-        compareModelsArray
-      );
-  
-      saveAs(content, filename);
+      let compareModelsArray = null;
+      compareModelsArray = compareModelsValue.split(",").filter(Number);
+      if (compareModelsArray.length != compareModelsValue.split(",").length) {
+        setIsCompareModelCorrect(false)
+        setIsCompareModelCorrectMessage("Was not able to concert comma separated string to a list of number - please provide a list such as 1, 2, 3")
+      } else {
+        setIsCompareModelCorrect(true)
+        let { filename, content } = await Backend.compareModels(
+          keycloak.token,
+          compareModelsArray
+        );
+        saveAs(content, filename);
+      }
     }
   };
 
@@ -255,7 +261,7 @@ export default function ModelsTable({
         {title}{' '}
         <div className="button-container">
           {showComparisonButtons &&
-            <>
+            <> 
               <input
                 type="text"
                 defaultValue={""}
@@ -281,6 +287,11 @@ export default function ModelsTable({
           >
             <FontAwesomeIcon icon="file-export" /> Export as CSV
           </Button>
+          {!isCompareModelCorrect && (
+                <Alert color="danger">
+                  {isCompareModelCorrectMessage}
+                </Alert>
+          )}
         </div>
       </h4>
       <Table {...getTableProps()} className="m-3 models-summary">

--- a/src/services/common.js
+++ b/src/services/common.js
@@ -76,9 +76,6 @@ export async function downloadFile(url, token, data = null) {
       options["method"] = "POST";
     }
 
-    console.log("download file options");
-    console.log(options);
-
     let response = await fetch(url, options);
 
     let fileContent = await response.blob();


### PR DESCRIPTION
This adds an error message modal to the compare model input field that shows an error message if it could not convert the input to a list of integers.

![image](https://github.com/medgift/quantimage2-frontend/assets/8817639/df9d4141-a687-4c41-8394-8e4e4d47a918)
