### PR TITLE
compare models button says classification only

### DIFF
--- a/src/components/ModelsTable.js
+++ b/src/components/ModelsTable.js
@@ -299,7 +299,7 @@ export default function ModelsTable({
                 className='compare_button'
                 onClick={handleCompareModels}
               >
-                <FontAwesomeIcon icon="file-export" /> Compare Models
+                <FontAwesomeIcon icon="file-export" /> Compare Models (Classification Only)
               </Button>
             </>
           }


### PR DESCRIPTION
Compare models button states that it only works for classification models

<img width="860" alt="image" src="https://github.com/medgift/quantimage2-frontend/assets/8817639/40292e98-1939-4c8f-830c-069593be4b54">
